### PR TITLE
Support pkglist property and quote property values

### DIFF
--- a/_modules/iocage.py
+++ b/_modules/iocage.py
@@ -72,7 +72,7 @@ def _parse_properties(**kwargs):
             raise SaltInvocationError('Unknown property %s' % (prop,))
 
     return ' '.join(
-        ['%s=%s' % (k, v) for k, v in kwargs.items() if not k.startswith('__')])
+        ['%s="%s"' % (k, v) for k, v in kwargs.items() if not k.startswith('__')])
 
 
 def _list(option=None, **kwargs):

--- a/_modules/iocage.py
+++ b/_modules/iocage.py
@@ -66,6 +66,7 @@ def _parse_properties(**kwargs):
     argument
     '''
     default_properties = [p.split('=')[0] for p in _list_properties('defaults')]
+    default_properties.append('pkglist')
 
     for prop in kwargs.keys():
         if not prop.startswith('__') and prop not in default_properties:

--- a/_states/iocage.py
+++ b/_states/iocage.py
@@ -71,6 +71,8 @@ def managed(name, properties=None, **kwargs):
         jail_exists = False
 
         jails = __salt__['iocage.list_jails']().split('\n')
+        templates = __salt__['iocage.list_templates']().split('\n')
+        jails = jails + templates
         for jail in jails:
             jail_datas = {j.split('=')[0]: '='.join(j.split('=')[1:])
                           for j in jail.split(',')}


### PR DESCRIPTION
Currently, having the yaml property `notes: this is a test jail` results in the command `iocage create notes=this is a test jail`. It should be `iocage create notes="this is a test jail"`

Also, iocage takes an optional property pkglist to install a list of packages. This is not part of the default properties and currenlty throws unknown property error. Manually add pkglist to the list of properties to check.
