### PR TITLE
Error Fixes

### DIFF
--- a/_modules/iocage.py
+++ b/_modules/iocage.py
@@ -252,7 +252,8 @@ def fetch(release=None, **kwargs):
         salt '*' iocage.fetch <release>
     '''
     if release is None:
-        return _exec('iocage fetch')
+        current_release = _exec('uname -r').strip()
+        return _exec('iocage fetch release=%s' % (current_release,))
     else:
         return _exec('iocage fetch release=%s' % (release,))
 
@@ -313,6 +314,11 @@ def create(jail_type="full", template_id=None, **kwargs):
     existing_release = list_releases()
     if len(existing_release) == 0:
         fetch()
+
+    # fetch a specifc release if not present
+    if 'release' in kwargs.keys():
+        if kwargs['release'] in existing_release:
+            fetch(release=kwargs['release'])
 
     if len(properties) > 0:
         cmd = '%s %s' % (pre_cmd, properties)

--- a/_modules/iocage.py
+++ b/_modules/iocage.py
@@ -317,7 +317,7 @@ def create(jail_type="full", template_id=None, **kwargs):
 
     # fetch a specifc release if not present
     if 'release' in kwargs.keys():
-        if kwargs['release'] in existing_release:
+        if kwargs['release'] not in existing_release:
             fetch(release=kwargs['release'])
 
     if len(properties) > 0:

--- a/_states/iocage.py
+++ b/_states/iocage.py
@@ -75,12 +75,17 @@ def managed(name, properties=None, jail_type="full", template_id=None, **kwargs)
         templates = __salt__['iocage.list_templates']().split('\n')
         jails = jails + templates
         for jail in jails:
+            # check if the jails or templates list is empty which results in an empty string in the array
+            if not jail:
+                continue
             jail_datas = {j.split('=')[0]: '='.join(j.split('=')[1:])
                           for j in jail.split(',')}
             if jail_datas['TAG'] == name or jail_datas['UUID'] == name:
                 jail_exists = True
                 break
-    except:
+    except Exception as e:
+        log.debug("########## UNABLE TO CHECK IF JAIL EXISTS OR NOT ")
+        log.debug(e)
         if __opts__['test']:
             ret['result'] = None
         ret['comment'] = 'unable to check if jail exists or not'
@@ -137,7 +142,8 @@ def managed(name, properties=None, jail_type="full", template_id=None, **kwargs)
                             __salt__['iocage.create'](tag=name, jail_type=jail_type, template_id=template_id, **properties)
                         else:
                             __salt__['iocage.create'](tag=name, **kwargs)
-                except e:
+                except Exception as e:
+                    log.debug('####### FAIL INSTALLING NEW JAIL')
                     log.debug(e)
                     ret['result'] = False
                     ret['comment'] = 'fail installing new jail %s' % (name,)


### PR DESCRIPTION
- Fix error when no existing jail or template present  
- By default, fetch the current  version using uname -r ( currently hangs for user input)
- When release property is specified, check if it is downloaded, else fetch it.
