### PR TITLE
Bugfix to ignore non-iocage jails

### DIFF
--- a/_modules/iocage.py
+++ b/_modules/iocage.py
@@ -99,6 +99,9 @@ def _list(option=None, **kwargs):
         jails = []
         if len(lines) > 1:
             for l in lines[1:]:
+                # omit all non-iocage jails
+                if l == '--- non iocage jails currently active ---':
+                    break
                 jails.append({
                     headers[k]: v for k, v in enumerate([_ for _ in l.split(' ')
                                                          if len(_) > 0])


### PR DESCRIPTION
iocage list also reports any running jails that were not created using
iocage, but in a different format. This breaks the parsing code.

Added a check to ignore anything after
'--- non iocage jails currently active ---'
